### PR TITLE
Allow unauthenticated access to v1/_ping

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -22,4 +22,9 @@ server {
       auth_basic_user_file /etc/nginx/.htpasswd;
       proxy_pass http://{{REGISTRY_HOST}}:{{REGISTRY_PORT}};
     }
+    location /v1/_ping {
+      auth_basic off;
+      return 200 'V2 registry';
+    }
+
 }


### PR DESCRIPTION
docker-py expects to be able to ping either /v2 or /v1/_ping in order to validate the registry; it's easier here to just do a carve-out for the V1 ping endpoint since we are a V2 registry. See: https://github.com/docker/docker-py/blob/master/docker/auth/auth.py#L29 and https://github.com/signalfuse/maestro-ng/issues/76
