### PR TITLE
Proxy the port number

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -8,7 +8,7 @@ server {
     ssl_certificate /etc/nginx/ssl/docker-registry.crt;
     ssl_certificate_key /etc/nginx/ssl/docker-registry.key;
 
-    proxy_set_header Host $host;
+    proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
required by docker daemon when running on non-standard SSL port
