### PR TITLE
add configurable proxy timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ MAINTAINER Container Solutions <info@container-solutions.com>
 COPY default.conf /etc/nginx/conf.d/default.conf
 COPY entrypoint.sh /entrypoint.sh
 
+ENV PROXY_TIMEOUT 300s
+
 ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/default.conf
+++ b/default.conf
@@ -14,6 +14,8 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Original-URI $request_uri;
     proxy_set_header Docker-Distribution-Api-Version registry/2.0;
+    proxy_read_timeout {{PROXY_TIMEOUT}};
+    proxy_send_timeout {{PROXY_TIMEOUT}};
 
     client_max_body_size 0; # disable any limits to avoid HTTP 413 for large image uploads
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
-sed -i "s|{{REGISTRY_HOST}}|$REGISTRY_HOST|;s|{{REGISTRY_PORT}}|$REGISTRY_PORT|;s|{{SERVER_NAME}}|$SERVER_NAME|" /etc/nginx/conf.d/default.conf
+sed -i "s|{{REGISTRY_HOST}}|$REGISTRY_HOST|;s|{{PROXY_TIMEOUT}}|$PROXY_TIMEOUT|;s|{{REGISTRY_PORT}}|$REGISTRY_PORT|;s|{{SERVER_NAME}}|$SERVER_NAME|" /etc/nginx/conf.d/default.conf
 exec "$@"


### PR DESCRIPTION
I faced https://github.com/docker/docker-registry/issues/900 issue today. Docker guys recommends to increase timeout in the fronted nginx. This PR adds ability to configure proxy timeouts.
